### PR TITLE
docs: update README with ICASSP 2026 badge, authors and formatting cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 <div align="center">
-    <h1>
-  MLC-SLM
-    </h1>
-    <p>
+  <h1>MLC-SLM</h1>
+  <p>
     Official PyTorch code for paper <br>
     <b><em>BRIDGING THE GAP: A COMPARATIVE EXPLORATION OF SPEECH-LLM AND END-TO-END ARCHITECTURE FOR MULTILINGUAL CONVERSATIONAL ASR</em></b>
-    </p>
-    <p>
-    </p>
-    <a href="http://arxiv.org/abs/2601.01461"><img src="https://img.shields.io/badge/Paper-ArXiv-red" alt="paper"></a>
-    <a href="https://huggingface.co/YuCeong-May/MLC-SLM/"><img src="https://img.shields.io/badge/Hugging%20Face-Model%20Page-yellow" alt="HF-model"></a>
-    <a href="https://github.com/FireRedTeam/FireRedTTS"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="Apache-2.0"></a>
+  </p>
+
+  <a href="https://ieeexplore.ieee.org/document/10970280"><img src="https://img.shields.io/badge/ICASSP-2026-8A2BE2" alt="icassp"></a>
+  <a href="http://arxiv.org/abs/2601.01461"><img src="https://img.shields.io/badge/Paper-ArXiv-red" alt="paper"></a>
+  <a href="https://huggingface.co/YuCeong-May/MLC-SLM/"><img src="https://img.shields.io/badge/Hugging%20Face-Model%20Page-yellow" alt="HF-model"></a>
+  <a href="https://github.com/FireRedTeam/FireRedTTS"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="Apache-2.0"></a>
+
+  <p><br>
+    <b>Yuxiang Mei<sup>1</sup>, Dongxing Xu<sup>1</sup>, Jiaen Liang<sup>1</sup>, Yanhua Long<sup>1</sup></b><br>
+    <sup>1</sup><a href="https://www.shnu.edu.cn/">Shanghai Normal University</a>, China
+  </p>
+
+  <p><b>ICASSP 2026</b></p>
 </div>
 
 # Dataset
@@ -83,7 +88,7 @@ All checkpoints can be found at: [Hugging Face – MLC-SLM](https://huggingface.
 
 # Citation
 
-If you find this work useful, please cite our paper as follows:
+If you find this work useful, please cite our ICASSP 2026 paper as follows:
 
 ```bibtex
 @article{mlcslm2026bridging,
@@ -92,4 +97,5 @@ If you find this work useful, please cite our paper as follows:
   journal = {arXiv preprint arXiv:2601.01461},
   year    = {2026}
 }
+
 ```


### PR DESCRIPTION
### Motivation
- Reflect the paper's ICASSP 2026 acceptance and add author and affiliation metadata to the project README.

### Description
- Tidy the README header HTML and spacing, add an `ICASSP 2026` badge and reorder project badges for prominence.
- Add author list with affiliation and a short ICASSP 2026 label, and update the citation line to reference the ICASSP 2026 paper.
- Minor formatting adjustments to the README layout and BibTeX block for improved readability.

### Testing
- This is a documentation-only change to `README.md`, so no automated unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a155edd6e70832dbac9a3e7ee75fb8d)